### PR TITLE
Fix QuickSwitch integer-division bug masking SwitchDelay DB field

### DIFF
--- a/UberStrike.Unity/Assets/Scripts/WeaponControl/WeaponFeedbackManager.cs
+++ b/UberStrike.Unity/Assets/Scripts/WeaponControl/WeaponFeedbackManager.cs
@@ -343,7 +343,12 @@ public class WeaponFeedbackManager : MonoSingleton<WeaponFeedbackManager>
         public PickUpState(BaseWeaponLogic weapon, BaseWeaponDecorator decorator)
             : base(weapon, decorator)
         {
-            _transitionTime = Mathf.Max(Instance.WeaponAnimation.PickUpDuration, weapon.Config.SwitchDelayMilliSeconds / 1000);
+            // SwitchDelayMilliSeconds is an int in milliseconds; PickUpDuration is a float in seconds.
+            // The previous `/ 1000` was an integer divide that returned 0 for any value < 1000ms (e.g.
+            // the default _switchDelay = 500 -> 0), making the per-weapon [CustomProperty("SwitchDelay")]
+            // database field functionally dead. Use `/ 1000f` so the float divide is preserved and
+            // server-driven per-weapon switch delays actually take effect.
+            _transitionTime = Mathf.Max(Instance.WeaponAnimation.PickUpDuration, weapon.Config.SwitchDelayMilliSeconds / 1000f);
             if (decorator.IsMelee)
             {
                 _currentRotation = -90;


### PR DESCRIPTION
## Summary

`WeaponFeedbackManager.PickUpState..ctor` computes `_transitionTime` as:

```csharp
_transitionTime = Mathf.Max(Instance.WeaponAnimation.PickUpDuration,
                            weapon.Config.SwitchDelayMilliSeconds / 1000);
```

Both operands of `/` are `int` (`SwitchDelayMilliSeconds` is an `int` field, `1000` is an int literal). The divide truncates to `0` for any value `< 1000ms`. With the default `_switchDelay = 500`, the per-weapon switch delay evaluates to `0`, `Mathf.Max` falls through to `PickUpDuration`, and the `[CustomProperty("SwitchDelay")]` DB-driven field is functionally dead.

One-char fix: `/ 1000` → `/ 1000f`. Float divide is preserved end-to-end and the existing server-driven per-weapon `SwitchDelay` value takes effect switch delay can now be tuned per weapon from the database without further client changes.

## Background

This was uncovered while investigating public issue #45 (QuickSwitch delay). The original input-handler fix for that issue (45cb2d7e on `constripacity/unity_2022_tg`, squashed into #35's `6c8e0b32`) was per request reverted in #35 commit `aee8b961`, moving QS work to a dedicated PR. This PR is the *minimal* fix HaZard asked for in Discord: *"lets fix the bug and then start using the database value."*

No behavior change for weapons with `SwitchDelay >= 1000` (the previous integer divide produced the correct seconds value at those boundaries).

## Test plan

- [ ] Editor: open a match, verify switch delay matches the configured `SwitchDelay` for default weapons (500ms for HandGun/Splatbat-class) switch-then-fire timing should feel ~half the previous 1000ms-pickup-anim gate, not instant
- [ ] Verify holdouts: SniperRifle (1500ms) still feels distinct from MachineGun (125ms)
- [ ] Standalone build: same checks, parity with Editor
- [ ] Server tuning: once DB rows update, no further client work needed

