### PR TITLE
add https support

### DIFF
--- a/UberStrike.Unity/Assets/Editor/SceneExporter.cs
+++ b/UberStrike.Unity/Assets/Editor/SceneExporter.cs
@@ -12,8 +12,8 @@ public class SceneExporter
     public const string BaseContentUrlExternalQA = "http://client-qa.uberforever.eu/";
     public const string BaseContentUrlInternalDev = "http://client-dev.uberforever.eu/";
 
-    public const string BaseWebServiceUrlProduction = "http://ws.uberforever.eu/";
-    public const string BaseWebServiceUrlExternalQA = "http://ws-qa.uberforever.eu/";
+    public const string BaseWebServiceUrlProduction = "https://ws.uberforever.eu/";
+    public const string BaseWebServiceUrlExternalQA = "https://ws-qa.uberforever.eu/";
     public const string BaseWebServiceUrlInternalDev = "https://ws-dev.uberforever.eu/";
 
     public static readonly string WebPlayerFolder = Application.dataPath + "/../Latest/WebPlayer";

--- a/UberStrike.Unity/Assets/Scripts/WeaponControl/WeaponLogic/ProjectileWeapon.cs
+++ b/UberStrike.Unity/Assets/Scripts/WeaponControl/WeaponLogic/ProjectileWeapon.cs
@@ -124,7 +124,10 @@ public class ProjectileWeapon : BaseWeaponLogic
                 //Let projectile know it's ID
                 projectile.gameObject.tag = "Prop";
                 projectile.ExplosionEffect = ExplosionType;
-                projectile.TimeOut = _decorator.MissileTimeOut;
+				if(_decorator.MissileTimeOut > 0)
+				{
+                	projectile.TimeOut = _decorator.MissileTimeOut;
+				}
                 projectile.SetExplosionSound(_decorator.ExplosionSound);
 
                 projectile.transform.position = ray.origin + MinProjectileDistance * ray.direction;


### PR DESCRIPTION
Unity 2022 allows support for https and rejects http. Use https in the connection string, which is eg used in EditorConfiguration/UberStrike.xml.